### PR TITLE
Add typo for demo GIF recording

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ function App() {
     <div className="app-container">
       <header className="app-header">
         <h1>Feedback Widget Test App</h1>
-        <p className="subtitle">A simple todo list to test the feedback widget's element picker</p>
+        <p className="subtitle">A simple todo list to test the feedback widget's elment picker</p>
       </header>
 
       <div className="stats-bar">


### PR DESCRIPTION
## Summary
- Adds intentional typo ("elment" instead of "element") to subtitle for demo GIF recording

## Purpose
This typo gives us something realistic to circle and report when recording the demo GIF for the README. After the GIF is recorded, this can be reverted.