### PR TITLE
docs: enable optional name/email fields in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,26 @@ A free, open-source **GitHub App** that adds a feedback widget to your app:
 ## About This Demo
 
 WienerMatch is a fictional landing page used to demonstrate BugDrop. Issues submitted here go to this repo's [Issues](https://github.com/neonwatty/feedback-widget-test/issues).
+
+## Widget Configuration
+
+This demo shows **optional** name/email fields. You can configure these per your needs:
+
+```html
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  data-repo="your-org/your-repo"
+  data-show-name="true"      <!-- Optional: show name field -->
+  data-show-email="true"     <!-- Optional: show email field -->
+></script>
+```
+
+| Attribute | Description | Default |
+|-----------|-------------|---------|
+| `data-repo` | Your GitHub repository | **required** |
+| `data-show-name` | Display name input field | `false` |
+| `data-require-name` | Make name required | `false` |
+| `data-show-email` | Display email input field | `false` |
+| `data-require-email` | Make email required | `false` |
+
+See the [BugDrop documentation](https://github.com/neonwatty/bugdrop#widget-options) for all options.

--- a/index.html
+++ b/index.html
@@ -9,9 +9,27 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <!--
+      BugDrop Widget Configuration
+
+      Required:
+        data-repo: Your GitHub repository (owner/repo)
+
+      Optional (shown here for demo purposes):
+        data-show-name: Show name field (default: false)
+        data-require-name: Make name required (default: false)
+        data-show-email: Show email field (default: false)
+        data-require-email: Make email required (default: false)
+        data-theme: light | dark | auto (default: auto)
+        data-position: bottom-right | bottom-left (default: bottom-right)
+
+      See https://github.com/neonwatty/bugdrop for full documentation.
+    -->
     <script
       src="https://bugdrop.neonwatty.workers.dev/widget.js"
       data-repo="neonwatty/feedback-widget-test"
+      data-show-name="true"
+      data-show-email="true"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Enable optional name and email fields in the demo to showcase BugDrop's configurable submitter info feature.

## Changes
- **index.html**: Add `data-show-name` and `data-show-email` attributes (both optional, not required)
- **index.html**: Add detailed HTML comment documenting all widget options
- **README.md**: Add Widget Configuration section explaining the optional fields

## Key Points
- Both fields shown but **not required** - users can skip them
- Clear documentation that these are **optional** configuration options
- Links to main BugDrop repo for full documentation

## Demo Behavior
After merge, the demo will show Name and Email fields in the feedback form. Users can fill them in or leave them blank - the feedback will still submit either way.