### PR TITLE
docs: add customization note to demo explainer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1218,6 +1218,13 @@ body {
   font-weight: 500;
 }
 
+.explainer-note {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  font-weight: 500;
+  font-style: italic;
+}
+
 .explainer-links {
   display: flex;
   gap: 10px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -409,9 +409,10 @@ function App() {
         <div className="explainer-content">
           <span className="explainer-title">Try BugDrop</span>
           <span className="explainer-desc">In-app feedback → GitHub Issues</span>
+          <span className="explainer-note">Add name/email fields, themes & more</span>
           <div className="explainer-links">
-            <a href="https://github.com/neonwatty/bugdrop" target="_blank" rel="noopener noreferrer">
-              GitHub
+            <a href="https://github.com/neonwatty/bugdrop#widget-options" target="_blank" rel="noopener noreferrer">
+              Customize
             </a>
             <a href="https://github.com/apps/neonwatty-bugdrop/installations/new" target="_blank" rel="noopener noreferrer">
               Install


### PR DESCRIPTION
## Summary
- Add a note to the BugDrop explainer callout mentioning customization options
- Replace "GitHub" link with "Customize" that links directly to Widget Options section
- Helps demo visitors understand that name/email fields, themes, and more are available

## Changes
- **Explainer callout**: Added italic note "Add name/email fields, themes & more"
- **Links**: Changed "GitHub" → "Customize" pointing to `#widget-options`

## Screenshot
The explainer callout in the bottom-left corner now shows:
```
Try BugDrop
In-app feedback → GitHub Issues
Add name/email fields, themes & more
[Customize] [Install] [Demo Issues]
```