### PR TITLE
docs: unify messaging with primary value prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BugDrop Demo
 
-Live demo of [BugDrop](https://github.com/neonwatty/bugdrop) — a free, open-source GitHub App that lets users give feedback right in your app.
+Live demo of [BugDrop](https://github.com/neonwatty/bugdrop) — a free, open-source widget: in-app feedback → GitHub Issues.
 
 **Try it:** https://neonwatty.github.io/feedback-widget-test/
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,8 +57,8 @@ function App() {
         <div className="demo-banner-content">
           <span className="demo-banner-icon">🐛</span>
           <span className="demo-banner-text">
-            <strong>BugDrop</strong> — Let users give feedback right in your app!
-            Screenshots & comments → GitHub Issues. Free & open source.
+            <strong>BugDrop</strong> — In-app feedback → GitHub Issues.
+            Screenshots, annotations, the works. Free & open source.
           </span>
           <div className="demo-banner-links">
             <a href="https://github.com/neonwatty/bugdrop" target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
Update messaging to lead with the core value proposition, aligning with the main BugDrop repo:

**"In-app feedback → GitHub Issues"**

## Changes
- `README.md` - Updated description on line 3
- `src/App.tsx` - Updated demo banner (lines 59-62)

This aligns the demo site messaging with the main BugDrop repo (PR neonwatty/bugdrop#13).