### PR TITLE
feat: add BugDrop CTA section to demo site

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -992,6 +992,98 @@ body {
 }
 
 /* ===========================================
+   BugDrop CTA Section
+   =========================================== */
+
+.bugdrop-cta-section {
+  position: relative;
+  z-index: 1;
+  padding: 5rem 2rem;
+  background: linear-gradient(135deg, #1a1b26 0%, #24283b 100%);
+  text-align: center;
+  border-top: 1px solid rgba(255, 158, 100, 0.2);
+}
+
+.bugdrop-cta-content {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.bugdrop-cta-icon {
+  font-size: 3.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.bugdrop-cta-section h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+  color: #c0caf5;
+  margin-bottom: 1rem;
+}
+
+.bugdrop-cta-section p {
+  color: #787c99;
+  font-size: 1.1rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.bugdrop-cta-buttons {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.btn-bugdrop-primary {
+  background: linear-gradient(135deg, #ff9e64 0%, #f7768e 100%);
+  color: #1a1b26;
+  font-weight: 600;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  text-decoration: none;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 15px rgba(255, 158, 100, 0.3);
+}
+
+.btn-bugdrop-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(255, 158, 100, 0.4);
+}
+
+.btn-bugdrop-secondary {
+  background: rgba(255, 255, 255, 0.1);
+  color: #c0caf5;
+  font-weight: 500;
+  padding: 1rem 2rem;
+  border-radius: 12px;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  transition: all 0.3s ease;
+}
+
+.btn-bugdrop-secondary:hover {
+  background: rgba(255, 255, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+.bugdrop-cta-note {
+  font-size: 0.9rem;
+  color: #565f89;
+  margin: 0;
+}
+
+.bugdrop-cta-note a {
+  color: #7dcfff;
+  text-decoration: none;
+}
+
+.bugdrop-cta-note a:hover {
+  text-decoration: underline;
+}
+
+/* ===========================================
    Footer
    =========================================== */
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -388,6 +388,26 @@ function App() {
         </div>
       </section>
 
+      {/* BugDrop CTA Section */}
+      <section className="bugdrop-cta-section">
+        <div className="bugdrop-cta-content">
+          <div className="bugdrop-cta-icon">🐛</div>
+          <h2>Like this feedback widget?</h2>
+          <p>Add BugDrop to your site in 2 minutes. Free, open source, and creates GitHub Issues automatically.</p>
+          <div className="bugdrop-cta-buttons">
+            <a href="https://github.com/apps/neonwatty-bugdrop/installations/new" target="_blank" rel="noopener noreferrer" className="btn btn-bugdrop-primary">
+              Install Free →
+            </a>
+            <a href="https://github.com/neonwatty/bugdrop" target="_blank" rel="noopener noreferrer" className="btn btn-bugdrop-secondary">
+              View on GitHub
+            </a>
+          </div>
+          <p className="bugdrop-cta-note">
+            See the <a href="https://github.com/neonwatty/feedback-widget-test/issues" target="_blank" rel="noopener noreferrer">issues created by this demo</a>
+          </p>
+        </div>
+      </section>
+
       {/* Footer */}
       <footer className="app-footer">
         <div className="footer-content">


### PR DESCRIPTION
## Summary
Add a prominent call-to-action section for BugDrop to help convert demo visitors into users.

## Changes
- New "Like this feedback widget?" CTA section between WienerMatch CTA and footer
- "Install Free" and "View on GitHub" buttons
- Link to issues created by the demo for social proof
- Tokyo Night color scheme to match BugDrop brand

## Screenshot
The new section appears after scrolling past the WienerMatch content, providing a clear next step for visitors who tried the widget.