### PR TITLE
feat: enable dismissible button for BugDrop widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,12 +22,14 @@
         data-require-email: Make email required (default: false)
         data-theme: light | dark | auto (default: auto)
         data-position: bottom-right | bottom-left (default: bottom-right)
+        data-button-dismissible: Allow users to dismiss the button (default: false)
 
       See https://github.com/neonwatty/bugdrop for full documentation.
     -->
     <script
       src="https://bugdrop.neonwatty.workers.dev/widget.js"
       data-repo="neonwatty/feedback-widget-test"
+      data-button-dismissible="true"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Enable the new dismissible button feature for the BugDrop feedback widget
- Users can now dismiss the feedback button by clicking the X icon that appears on hover
- Preference is saved to localStorage and persists across page loads

## Changes
- Added `data-button-dismissible="true"` attribute to the widget script tag
- Updated configuration comments to document the new option

## Requirements
This feature requires BugDrop v1.1.0 or later (once released).

## Test plan
- [ ] Verify the feedback button appears on page load
- [ ] Hover over the button and confirm the X close icon appears
- [ ] Click the X to dismiss the button
- [ ] Refresh the page and confirm the button stays hidden
- [ ] Clear localStorage to restore the button