### PR TITLE
feat: add JavaScript API demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,15 @@
         data-theme: light | dark | auto (default: auto)
         data-position: bottom-right | bottom-left (default: bottom-right)
         data-button-dismissible: Allow users to dismiss the button (default: false)
+        data-button: Show/hide floating button (default: true, set false for API-only)
+
+      JavaScript API:
+        window.BugDrop.open()   - Open feedback modal programmatically
+        window.BugDrop.close()  - Close the modal
+        window.BugDrop.hide()   - Hide floating button
+        window.BugDrop.show()   - Show floating button
+        window.BugDrop.isOpen() - Check if modal is open
+        window.BugDrop.isButtonVisible() - Check if button is visible
 
       See https://github.com/neonwatty/bugdrop for full documentation.
     -->

--- a/src/App.css
+++ b/src/App.css
@@ -277,6 +277,19 @@ body {
   color: var(--accent-orange);
 }
 
+.nav-report-bug {
+  cursor: pointer;
+  color: var(--accent-orange);
+  background: rgba(255, 107, 53, 0.1);
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.nav-report-bug:hover {
+  background: rgba(255, 107, 53, 0.2);
+}
+
 .nav-cta {
   background: var(--accent-orange);
   color: white;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,20 @@
 import { useState } from 'react'
 import './App.css'
 
+// BugDrop API type declaration
+declare global {
+  interface Window {
+    BugDrop?: {
+      open: () => void;
+      close: () => void;
+      hide: () => void;
+      show: () => void;
+      isOpen: () => boolean;
+      isButtonVisible: () => boolean;
+    };
+  }
+}
+
 interface Todo {
   id: number
   text: string
@@ -89,6 +103,15 @@ function App() {
           <a href="#how-it-works" className="nav-link">How It Works</a>
           <a href="#features" className="nav-link">Features</a>
           <a href="#demo" className="nav-link">Find Your Doxie</a>
+          <span
+            className="nav-link nav-report-bug"
+            onClick={() => window.BugDrop?.open()}
+            role="button"
+            tabIndex={0}
+            onKeyPress={(e) => e.key === 'Enter' && window.BugDrop?.open()}
+          >
+            🐛 Report Bug
+          </span>
           <a href="#" className="nav-cta">Get Started</a>
         </div>
       </nav>
@@ -429,10 +452,10 @@ function App() {
         <div className="explainer-content">
           <span className="explainer-title">Try BugDrop</span>
           <span className="explainer-desc">In-app feedback → GitHub Issues</span>
-          <span className="explainer-note">Add name/email fields, themes & more</span>
+          <span className="explainer-note">JS API, themes, dismissible & more</span>
           <div className="explainer-links">
-            <a href="https://github.com/neonwatty/bugdrop#widget-options" target="_blank" rel="noopener noreferrer">
-              Customize
+            <a href="https://github.com/neonwatty/bugdrop#javascript-api" target="_blank" rel="noopener noreferrer">
+              JS API
             </a>
             <a href="https://github.com/apps/neonwatty-bugdrop/installations/new" target="_blank" rel="noopener noreferrer">
               Install


### PR DESCRIPTION
## Summary
- Add "🐛 Report Bug" link in the navigation that demonstrates `BugDrop.open()` API
- Update documentation comments with full JavaScript API reference
- Update explainer callout to link to JS API docs

## Demo
The navigation now includes a "Report Bug" link that opens the BugDrop feedback modal programmatically using the JavaScript API instead of the floating button.

This demonstrates how developers can integrate BugDrop into their own UI (menus, buttons, etc.) rather than relying solely on the floating button.

## Dependencies
Requires BugDrop v1.2.0 (currently in PR #19 on bugdrop repo).

## Test plan
- [ ] Click "Report Bug" in navigation opens the feedback modal
- [ ] Modal works the same as clicking the floating button
- [ ] Keyboard accessible (Enter key triggers modal)