### PR TITLE
fix: make API Demo more prominent and add dismiss-duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
       src="https://bugdrop.neonwatty.workers.dev/widget.js"
       data-repo="neonwatty/feedback-widget-test"
       data-button-dismissible="true"
+      data-dismiss-duration="1"
     ></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,9 @@ function App() {
             Screenshots, annotations, the works. Free & open source.
           </span>
           <div className="demo-banner-links">
+            <a href="#api-demo">
+              API Demo ↓
+            </a>
             <a href="https://github.com/neonwatty/bugdrop" target="_blank" rel="noopener noreferrer">
               GitHub
             </a>
@@ -534,16 +537,22 @@ function App() {
         <div className="explainer-content">
           <span className="explainer-title">Try BugDrop</span>
           <span className="explainer-desc">In-app feedback → GitHub Issues</span>
-          <span className="explainer-note">JS API, themes, dismissible & more</span>
+          <span className="explainer-note">Dismissed the button? Click below to restore it</span>
           <div className="explainer-links">
-            <a href="https://github.com/neonwatty/bugdrop#javascript-api" target="_blank" rel="noopener noreferrer">
-              JS API
+            <span
+              onClick={() => window.BugDrop?.show()}
+              role="button"
+              tabIndex={0}
+              onKeyPress={(e) => e.key === 'Enter' && window.BugDrop?.show()}
+              style={{ cursor: 'pointer' }}
+            >
+              🐛 Show Button
+            </span>
+            <a href="#api-demo">
+              API Demo
             </a>
             <a href="https://github.com/apps/neonwatty-bugdrop/installations/new" target="_blank" rel="noopener noreferrer">
               Install
-            </a>
-            <a href="https://github.com/neonwatty/feedback-widget-test/issues" target="_blank" rel="noopener noreferrer">
-              Demo Issues
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Add "API Demo ↓" link in top banner for immediate visibility
- Add "Show Button" link in explainer callout to restore dismissed BugDrop button
- Add link to API Demo section in explainer callout
- Add `data-dismiss-duration="1"` so dismissed button returns after 1 day

## Test plan

- [ ] "API Demo ↓" link in banner scrolls to section
- [ ] "Show Button" restores dismissed BugDrop button
- [ ] "API Demo" link in callout works
- [ ] Dismissed button returns after 1 day (or clear localStorage to test)