### PR TITLE
fix: add orange accent color to BugDrop widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       data-repo="neonwatty/feedback-widget-test"
       data-button-dismissible="true"
       data-dismiss-duration="1"
+      data-color="#FF6B35"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Adds `data-color="#FF6B35"` to the BugDrop widget script tag so the feedback pill matches the WienerMatch app's orange theme.

## Before
Teal/cyan colored pill (default BugDrop color)

## After
Orange pill matching the app's accent color