### PR TITLE
feat: configurable widget URL for Vercel preview deployments

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       See https://github.com/neonwatty/bugdrop for full documentation.
     -->
     <script
-      src="https://bugdrop.neonwatty.workers.dev/widget.js"
+      src="__BUGDROP_URL__/widget.js"
       data-repo="neonwatty/feedback-widget-test"
       data-button-dismissible="true"
       data-dismiss-duration="1"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,15 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: 'bugdrop-url',
+      transformIndexHtml(html) {
+        const url = process.env.VITE_BUGDROP_URL || 'https://bugdrop.neonwatty.workers.dev';
+        return html.replace('__BUGDROP_URL__', url);
+      },
+    },
+  ],
   base: '/feedback-widget-test/',
 })


### PR DESCRIPTION
## Summary

- Add `transformIndexHtml` Vite plugin to replace `__BUGDROP_URL__` placeholder at build time
- Replace hardcoded production widget URL in `index.html` with the placeholder
- Defaults to `https://bugdrop.neonwatty.workers.dev` when `VITE_BUGDROP_URL` is not set (backwards compatible with current GitHub Pages deployment)

This enables Vercel preview deployments to load the widget from the CF Workers preview worker instead of production, by setting `VITE_BUGDROP_URL` per environment in Vercel project settings.

## After merging — Vercel setup steps

1. Import this repo into Vercel ([vercel.com/new](https://vercel.com/new)) — auto-detects Vite
2. Set environment variables in Vercel project settings:

   | Variable | Production | Preview |
   |----------|-----------|---------|
   | `VITE_BUGDROP_URL` | `https://bugdrop.neonwatty.workers.dev` | `https://bugdrop-preview.<account>.workers.dev` |

3. Deploy a `preview` branch once to get a stable Vercel preview URL
4. Note the stable URL and update `<STABLE_VERCEL_PREVIEW_URL>` in bugdrop's `live-tests.yml`
5. Decide whether to remove `base: '/feedback-widget-test/'` from `vite.config.ts` (only needed for GitHub Pages subpath — Vercel serves from root)

## Test plan

- [x] `npm run build` succeeds — default URL substituted
- [x] `VITE_BUGDROP_URL=https://bugdrop-preview.neonwatty.workers.dev npm run build` — preview URL substituted
- [x] Existing GitHub Pages deployment unaffected (default fallback = production URL)