### PR TITLE
feat: restyle BugDrop widget with warm neutral palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       Required:
         data-repo: Your GitHub repository (owner/repo)
 
-      Optional (not enabled here - see docs for details):
+      Optional behavior (some enabled here - see docs for details):
         data-show-name: Show name field (default: false)
         data-require-name: Make name required (default: false)
         data-show-email: Show email field (default: false)
@@ -24,6 +24,16 @@
         data-position: bottom-right | bottom-left (default: bottom-right)
         data-button-dismissible: Allow users to dismiss the button (default: false)
         data-button: Show/hide floating button (default: true, set false for API-only)
+
+      Theming (enabled here — marketplace-screenshot polish, warm-neutral palette):
+        data-color: Primary accent color (buttons, focus ring)
+        data-bg: Modal background color
+        data-text: Primary text color
+        data-border-color: Input/button border color
+        data-border-width: Input/button border width in pixels (integer)
+        data-radius: Base border-radius in pixels; widget derives sm/md/lg internally
+        data-shadow: Shadow preset — "none" | "soft" | "hard"
+        data-font: Font family override (host must load the font; Space Grotesk default)
 
       JavaScript API:
         window.BugDrop.open()   - Open feedback modal programmatically
@@ -40,7 +50,13 @@
       data-repo="mean-weasel/bugdrop-widget-test"
       data-button-dismissible="true"
       data-dismiss-duration="1"
-      data-color="#FF6B35"
+      data-color="#f97316"
+      data-bg="#fffcf8"
+      data-text="#1c1410"
+      data-border-color="#c9a679"
+      data-border-width="2"
+      data-radius="9"
+      data-shadow="soft"
     ></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Tunes the BugDrop widget's `data-*` theming attributes on the test venue to produce a polished warm-neutral palette. Motivated by the BugDrop marketplace listing — the product screenshots needed to show the widget as a shipped indie SaaS product, not an engineering mockup.

## Changes

Modified the existing `<script>` tag in `index.html`:
- `data-color`: `#FF6B35` → `#f97316` (Tailwind orange-500)
- **+** `data-bg="#fffcf8"` (cream modal background)
- **+** `data-text="#1c1410"` (warm near-black)
- **+** `data-border-color="#c9a679"` (warm tan, visible against cream bg)
- **+** `data-border-width="2"` (doubled from default 1)
- **+** `data-radius="9"` (up from default 6)
- **+** `data-shadow="soft"` (warm drop shadow)

Also updated the HTML comment block above the `<script>` tag to document the newly-enabled theming attributes for future maintainers.

Design spec: https://github.com/mean-weasel/bugdrop/blob/main/docs/superpowers/specs/2026-04-14-widget-warm-neutral-restyle-design.md (lands with a separate docs PR to the bugdrop repo).

## Test plan

Visually verified locally by running the vite dev server and opening the widget:

- [x] Modal background is cream (`#fffcf8`), distinct from default near-white
- [x] Input fields have visible warm tan borders (~2px thick)
- [x] Orange accent matches `#f97316` on the Continue button and launcher pill
- [x] Modal has a soft warm drop shadow
- [ ] Vercel preview deploy URL loads the test venue
- [ ] Preview visual check mirrors the local verification above
- [ ] No regressions in widget functionality (open, fill, capture, annotate, submit)