### PR TITLE
Add back link to BugDrop landing page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -99,6 +99,16 @@ html {
   color: #9bb8fc;
 }
 
+.demo-banner-links .demo-banner-back {
+  color: #ff9e64;
+  background: rgba(255, 158, 100, 0.16);
+}
+
+.demo-banner-links .demo-banner-back:hover {
+  color: #ffc096;
+  background: rgba(255, 158, 100, 0.26);
+}
+
 @media (max-width: 768px) {
   .demo-banner-content {
     flex-direction: column;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,9 @@ function App() {
             Screenshots, annotations, the works. Free & open source.
           </span>
           <div className="demo-banner-links">
+            <a href="https://bugdrop.dev" className="demo-banner-back">
+              Back to BugDrop
+            </a>
             <a href="#api-demo">
               API Demo ↓
             </a>


### PR DESCRIPTION
## Summary
- add a Back to BugDrop link to the sample app demo banner
- style the link so users can easily return to the landing page

## Validation
- npm run lint
- npm run build