### PR TITLE
Highlight sample app feedback button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1501,6 +1501,29 @@ body {
   filter: drop-shadow(0 0 12px rgba(255, 158, 100, 0.8));
 }
 
+@media (max-width: 768px) {
+  .bugdrop-explainer {
+    bottom: 92px;
+    right: 18px;
+  }
+
+  .explainer-content {
+    display: none;
+  }
+
+  .explainer-arrow {
+    font-size: 2rem;
+    margin-right: 10px;
+  }
+
+  .feedback-button-spotlight {
+    right: 8px;
+    bottom: 8px;
+    width: 92px;
+    height: 92px;
+  }
+}
+
 @keyframes point-bounce {
   0%, 100% {
     transform: translate(0, 0);

--- a/src/App.css
+++ b/src/App.css
@@ -1391,6 +1391,33 @@ body {
   animation: fadeUp 0.5s ease-out 1s both;
 }
 
+.feedback-button-spotlight {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  width: 96px;
+  height: 96px;
+  border: 2px solid rgba(255, 158, 100, 0.72);
+  border-radius: 999px;
+  box-shadow:
+    0 0 0 10px rgba(255, 158, 100, 0.12),
+    0 0 34px rgba(247, 118, 142, 0.46);
+  pointer-events: none;
+  z-index: 998;
+  animation: feedback-spotlight-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes feedback-spotlight-pulse {
+  0%, 100% {
+    opacity: 0.84;
+    transform: scale(0.96);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
 .explainer-content {
   background: linear-gradient(135deg, #ff9e64 0%, #f7768e 100%);
   color: #1a1b26;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -536,11 +536,12 @@ function App() {
       </footer>
 
       {/* BugDrop Explainer Callout */}
+      <div className="feedback-button-spotlight" aria-hidden="true"></div>
       <div className="bugdrop-explainer">
         <div className="explainer-content">
           <span className="explainer-title">Try BugDrop</span>
           <span className="explainer-desc">In-app feedback → GitHub Issues</span>
-          <span className="explainer-note">Dismissed the button? Click below to restore it</span>
+          <span className="explainer-note">Use the feedback button below to send a test report</span>
           <div className="explainer-links">
             <span
               onClick={() => window.BugDrop?.show()}


### PR DESCRIPTION
## Summary
- add a pulsing spotlight around the sample app feedback button
- update the callout copy to direct users to send a test report

## Validation
- npm run lint
- npm run build
- Playwright rendered check: back link, spotlight, and callout are visible with no relevant console errors